### PR TITLE
Add client.reconnect method

### DIFF
--- a/silentarmy
+++ b/silentarmy
@@ -485,6 +485,9 @@ class Silentarmy:
                     #   hashReserved, nTime, nBits, clean_jobs ]
                     self.set_new_job(*msg['params'][:8])
                     self.update_mining_job()
+                elif msg['method'] == 'client.reconnect':
+                    print("Get reconnect command from pool. Try reconnect...")
+                    asyncio.ensure_future(self.reconnect())
                 else:
                     raise Exception('Unimplemented method: %s' % msg['method'])
             else:


### PR DESCRIPTION
Fix https://github.com/mbevand/silentarmy/issues/16 
I think it works. Please check it.
```
Stratum: invalid msg from server: Unimplemented method: client.reconnect: {'id': None, 'params': [], 'method': 'client.reconnect'}

Stratum: connection was closed (invalid user/pwd?)
Total 64.5 sol/s [dev0 32.4, dev1 31.4] 1243 shares
Connecting to equihash.eu.nicehash.com:3357 (attempt 6)
Stratum: SILENTARMY is not compatible with servers fixing the first 17 bytes of the nonce
```