### PR TITLE
Fix fatal error for multiple OpenCL platforms

### DIFF
--- a/main.c
+++ b/main.c
@@ -1202,7 +1202,12 @@ unsigned scan_platform(cl_platform_id plat, cl_uint *nr_devs_total,
     if (do_list_devices)
 	print_platform_info(plat);
     status = clGetDeviceIDs(plat, typ, 0, NULL, &nr_devs);
-    if (status != CL_SUCCESS)
+    // With multiple platforms, valid devices may not be on current platform
+    if (status == CL_DEVICE_NOT_FOUND){
+	debug("Device not found: clGetDeviceIDs (%d)\n", status);
+	return 0;
+    }
+    else if (status != CL_SUCCESS)
 	fatal("clGetDeviceIDs (%d)\n", status);
     if (nr_devs == 0)
 	return 0;


### PR DESCRIPTION
When multiple OpenCL platforms are installed on the same machine,
the miner would raise a fatal error if the device wasn't found on
the first platform. Slightly modified the error checking to
raise a debugging message, and return 0 if no devices are found
by clGetDeviceIDs for a given platform.